### PR TITLE
Player Stats scriptable object

### DIFF
--- a/Assets/Boss/Boss.prefab
+++ b/Assets/Boss/Boss.prefab
@@ -288,7 +288,7 @@ GameObject:
   - component: {fileID: 7371243991920564468}
   m_Layer: 8
   m_Name: Model
-  m_TagString: Untagged
+  m_TagString: Boss
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -991,7 +991,7 @@ GameObject:
   - component: {fileID: 6208915446036521333}
   m_Layer: 8
   m_Name: Boss
-  m_TagString: Untagged
+  m_TagString: Boss
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Player/Prefabs/Player.prefab
+++ b/Assets/Player/Prefabs/Player.prefab
@@ -336,14 +336,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9f53e0e11e77e784cbfef74fa67e13e4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _playerModel: {fileID: 905505463223941419}
   _bossHealth: {fileID: 0}
   camHolder: {fileID: 0}
+  _stats: {fileID: 11400000, guid: 5d4a5d8b9a1131847a0618baf0e28128, type: 2}
   baseMoveSpeed: 8
   playerRollSpeed: 22
   playerRollTime: 0.15
   rollIFrameDuration: 0.4
   dashParticle: {fileID: 7477765099212387787, guid: 0773a2f72e4c6d14e86ad059be509a2a, type: 3}
+  _playerModel: {fileID: 905505463223941419}
   bulletPrefab: {fileID: 2063947483988415485, guid: 109b112fa000a2e40b13b81e86e53031, type: 3}
   targetLayer:
     serializedVersion: 2
@@ -354,7 +355,6 @@ MonoBehaviour:
   busterFireVFX: {fileID: 3875565099562772278, guid: b49d1e8659c3ebe468481848c7d8bc03, type: 3}
   hitsToCharge: 35
   windDownTime: 2.5
-  IsPaused: 0
   playerHitSfx: {fileID: 11400000, guid: 2b46e1e46c042a344bb6e3f65cf6437b, type: 2}
   playerShootSfx: {fileID: 11400000, guid: bcea55f6b995a6349a6cb57843ebe252, type: 2}
   playerDodgeSfx: {fileID: 11400000, guid: 3956341321d8c8c488ffa90500990918, type: 2}
@@ -362,6 +362,7 @@ MonoBehaviour:
   playerSecondaryChargeSfx: {fileID: 11400000, guid: d4fe3e811887f74468ed4378268a32b2, type: 2}
   playerSecondaryFireSfx: {fileID: 11400000, guid: f24231c600cb6ce498980b1d900cf679, type: 2}
   bossHitSfx: {fileID: 11400000, guid: b4d59fd8b5e1e974184e186f2df48938, type: 2}
+  IsPaused: 0
   CanDie: 1
   InTutorial: 0
 --- !u!82 &951325374121236488

--- a/Assets/Player/Scripts/PlayerStats.cs
+++ b/Assets/Player/Scripts/PlayerStats.cs
@@ -1,0 +1,23 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PseudoSummon
+{
+    [CreateAssetMenu(menuName = "PlayerStats")]
+    public class PlayerStats : ScriptableObject
+    {
+        [Header("Movement")]
+        [SerializeField, Min(0)] public float BaseMoveSpeed;
+        [SerializeField, Min(0)] public float RollSpeed;
+        [SerializeField, Min(0)] public float RollDuration;
+        [SerializeField, Min(0)] public float RollInvincibilityDuration;
+
+        [Header("Combat")]
+        [SerializeField, Min(0)] public float PrimaryFireAttackInterval;
+        [SerializeField, Min(0)] public int BusterHitsToCharge;
+        [SerializeField, Min(0)] public float BusterCooldownTime;
+        [SerializeField] public LayerMask AttackCollisionMask;
+
+    }
+}

--- a/Assets/Player/Scripts/PlayerStats.cs.meta
+++ b/Assets/Player/Scripts/PlayerStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df136811999107342b1ffba944baa848
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Player/Stats.asset
+++ b/Assets/Player/Stats.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: df136811999107342b1ffba944baa848, type: 3}
+  m_Name: Stats
+  m_EditorClassIdentifier: 
+  BaseMoveSpeed: 8
+  RollSpeed: 22
+  RollDuration: 0.15
+  RollInvincibilityDuration: 0.4
+  PrimaryFireAttackInterval: 0.21
+  BusterHitsToCharge: 35
+  BusterCooldownTime: 2.5
+  AttackCollisionMask:
+    serializedVersion: 2
+    m_Bits: 256

--- a/Assets/Player/Stats.asset.meta
+++ b/Assets/Player/Stats.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d4a5d8b9a1131847a0618baf0e28128
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Create a player stats scriptable object class to extract several fields out of the player controller script.
Helps with:
- Readability; Less fields at top of script
- Able to tune various stats for player by creating multiple stat assets. Avoids having to remember each field's original value when testing.
- Allows for easy reassignment of various stats.